### PR TITLE
Add "#include <optional>" in helpers.h to appease GCC 11.2.1

### DIFF
--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <functional>
 #include <iomanip>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
I need this little tweak to resolve the following:

```
[ 92%] Building CXX object src/CMakeFiles/zeek-agent.dir/core/logger.cc.o
In file included from /home/christian/devel/zeek/zeek-agent-v2/src/core/configuration.h:6,
                 from /home/christian/devel/zeek/zeek-agent-v2/src/core/logger.cc:5:
/home/christian/devel/zeek/zeek-agent-v2/src/util/helpers.h:91:13: error: ‘optional’ in namespace ‘std’ does not name a template type
   91 | extern std::optional<std::string> getenv(const std::string& name);
      |             ^~~~~~~~
/home/christian/devel/zeek/zeek-agent-v2/src/util/helpers.h:12:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?
   11 | #include <set>
  +++ |+#include <optional>
   12 | #include <sstream>
make[3]: *** [src/CMakeFiles/zeek-agent.dir/build.make:118: src/CMakeFiles/zeek-agent.dir/core/logger.cc.o] Error 1
make[3]: *** Waiting for unfinished jobs....
```