### PR TITLE
Link against standard version of OpenSSL by default.

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -16,7 +16,11 @@ set(BROKER_DISABLE_DOCS ON)
 set(BROKER_DISABLE_TESTS ON)
 set(DISABLE_PYTHON_BINDINGS ON)
 set(ENABLE_STATIC_ONLY ON)
-set(OPENSSL_USE_STATIC_LIBS on)
+
+if ( USE_STATIC_LINKING )
+    set(OPENSSL_USE_STATIC_LIBS on)
+endif ()
+
 add_subdirectory(broker EXCLUDE_FROM_ALL)
 
 # pathfind's cmake config is too old and not really usable. Set it up ourselves.


### PR DESCRIPTION
So far we hardcoded always using the static OpenSSL libraries. Now
that's done only when with configured with ``--enable-static``,
otherwise we use whatever CMake determines being the default.