### PR TITLE
Disable communication with a Zeek instance if it's package version is too old.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,6 @@ else ()
     set(ZEEK_AGENT_VERSION_LONG "${ZEEK_AGENT_VERSION}")
 endif ()
 
-string(REGEX MATCH "([0-9]*)\.([0-9]*)\.([0-9]*).*" _ ${ZEEK_AGENT_VERSION})
-set(ZEEK_AGENT_VERSION_MAJOR "${CMAKE_MATCH_1}")
-set(ZEEK_AGENT_VERSION_MINOR "${CMAKE_MATCH_2}")
-set(ZEEK_AGENT_VERSION_PATCH "${CMAKE_MATCH_3}")
-math(EXPR ZEEK_AGENT_VERSION_NUMBER "${ZEEK_AGENT_VERSION_MAJOR} * 10000 + ${ZEEK_AGENT_VERSION_MINOR} * 100 + ${ZEEK_AGENT_VERSION_PATCH}")
-
 ### Platform-specific code.
 
 set(HAVE_POSIX $<bool:${UNIX}>)
@@ -117,7 +111,7 @@ endif ()
 message(
     "\n====================|  Zeek Agent Build Summary  |===================="
     "\n"
-    "\nVersion:               ${ZEEK_AGENT_VERSION_LONG} (${ZEEK_AGENT_VERSION_NUMBER})"
+    "\nVersion:               ${ZEEK_AGENT_VERSION_LONG}"
     "\n"
     "\nBuild type:            ${CMAKE_BUILD_TYPE}"
     "\nBuild directory:       ${PROJECT_BINARY_DIR}"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -11,7 +11,6 @@
 namespace zeek::agent {
 inline const auto Version = "${ZEEK_AGENT_VERSION}";
 inline const auto VersionLong = "${ZEEK_AGENT_VERSION_LONG}";
-inline const auto VersionNumber = ${ZEEK_AGENT_VERSION_NUMBER}l;
 inline const auto InstallLibDir = "${CMAKE_INSTALL_LIBDIR}";
 inline const auto InstallPrefix = "${CMAKE_INSTALL_PREFIX}";
 }

--- a/src/core/configuration.h
+++ b/src/core/configuration.h
@@ -94,6 +94,9 @@ struct Options {
     /** Logs a summary of the current settings to the debug log stream. */
     void debugDump();
 
+    /** Agent's numerical version number. This is set automatically and cannot changed externally. */
+    int64_t version_number;
+
     /** Mode of operation for the current process. */
     options::Mode mode = options::Mode::Standard;
 

--- a/src/tables/zeek_agent/zeek_agent.darwin.mm
+++ b/src/tables/zeek_agent/zeek_agent.darwin.mm
@@ -79,7 +79,7 @@ std::vector<std::vector<Value>> ZeekAgentDarwin::snapshot(const std::vector<tabl
     Value addrs = addresses();
     Value platform = platform::name();
     Value os_name = std::string("macOS ") + std::string([version UTF8String]);
-    Value agent = VersionNumber;
+    Value agent = options().version_number;
     Value broker = broker::version::string();
     Value uptime = std::chrono::system_clock::now() - startupTime();
     Value tables =

--- a/src/tables/zeek_agent/zeek_agent.linux.cc
+++ b/src/tables/zeek_agent/zeek_agent.linux.cc
@@ -143,7 +143,7 @@ std::vector<std::vector<Value>> ZeekAgentLinux::snapshot(const std::vector<table
     Value addrs = addresses();
     Value platform = platform::name();
     Value os_name = distribution();
-    Value agent = VersionNumber;
+    Value agent = options().version_number;
     Value broker = broker::version::string();
     Value uptime = std::chrono::system_clock::now() - startupTime();
     Value tables =

--- a/src/tables/zeek_agent/zeek_agent.test.cc
+++ b/src/tables/zeek_agent/zeek_agent.test.cc
@@ -11,5 +11,5 @@ TEST_CASE_FIXTURE(test::TableFixture, "zeek_agent" * doctest::test_suite("Tables
     useTable("zeek_agent");
 
     auto result = query("SELECT * from zeek_agent");
-    CHECK_EQ(result.get<int64_t>(0, "agent_version"), VersionNumber);
+    CHECK_EQ(result.get<int64_t>(0, "agent_version"), cfg.options().version_number);
 }

--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "util/fmt.h"
+#include "util/result.h"
 
 #include <algorithm>
 #include <chrono>
@@ -285,6 +286,9 @@ inline bool startsWith(const std::string& s, const std::string& prefix) { return
 
 /** Renders an integer in base62 ASCII. */
 std::string base62_encode(uint64_t i);
+
+/** Parsed a version string of the form `x.y.z-<N>` into a numerical number suitable for ordering. */
+zeek::agent::Result<int64_t> parseVersion(std::string v);
 
 /** Creates a new random UUID, encoded in base62 ASCII. */
 std::string randomUUID();


### PR DESCRIPTION
Closes #34 