### PR TITLE
Introduce p-ranav/glob library for file globbing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "3rdparty/vcpkg"]
 	path = 3rdparty/vcpkg
 	url = https://github.com/microsoft/vcpkg
+[submodule "3rdparty/glob"]
+	path = 3rdparty/glob
+	url = https://github.com/p-ranav/glob.git

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -33,6 +33,7 @@ add_subdirectory(json EXCLUDE_FROM_ALL)
 add_subdirectory(stduuid EXCLUDE_FROM_ALL)
 add_subdirectory(tomlplusplus EXCLUDE_FROM_ALL)
 add_subdirectory(out_ptr EXCLUDE_FROM_ALL)
+add_subdirectory(glob EXCLUDE_FROM_ALL)
 
 set(SPDLOG_FMT_EXTERNAL ON)
 add_subdirectory(spdlog EXCLUDE_FROM_ALL)

--- a/3rdparty/LICENSE.3rdparty
+++ b/3rdparty/LICENSE.3rdparty
@@ -121,6 +121,32 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
+glob
+================================================================================
+
+MIT License
+
+Copyright (c) 2019 Pranav
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
 nlohmann::json
 ================================================================================
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ target_link_libraries(zeek-agent PRIVATE sqlite::sqlite)
 target_link_libraries(zeek-agent PRIVATE stduuid)
 target_link_libraries(zeek-agent PRIVATE tomlplusplus::tomlplusplus)
 target_link_libraries(zeek-agent PRIVATE ztd::out_ptr)
+target_link_libraries(zeek-agent PRIVATE Glob)
 
 if ( NOT HAVE_GETOPT_LONG )
     target_link_libraries(zeek-agent PRIVATE 3rdparty:3rdparty)


### PR DESCRIPTION
This adds the p-ranav/glob library to replace using OS-specific glob methods, and replaces all of the Windows-API-based code in files.windows.cc with normal `filesystem` methods to do the same thing. The code between Windows and POSIX could potentially be combined into a single file, since they are very close to each other at this point.

There is one additional TODO I added at the error case in `FilesLinesWindows::snapshot`. First off, this error case probably isn't being hit by the tests. The table requires four columns but we're only inserting three here (we're missing the `pattern` column). I only discovered this because we fall into this `if` block when we hit the `sub` directory added to the test when it can't be opened by `ifstream`. I added a check for directories to get around it temporarily.