### PR TITLE
Update vcpkg to 2023.11.20

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
     "name": "main",
     "version-string": "latest",
     "dependencies": [
+	"pthreads",
 	"openssl",
 	"zlib"
     ]


### PR DESCRIPTION
This fixes the build on Windows failing to find zlib.