### PR TITLE
Avoid dereferencing cookie field that could intentionally be unset

### DIFF
--- a/src/io/zeek.cc
+++ b/src/io/zeek.cc
@@ -1268,7 +1268,7 @@ void ZeekConnection::processEvent(const std::string& name, const std::vector<Val
                                    .requires_tables = std::move(requires_tables),
                                    .if_missing_tables = std::move(if_missing_tables),
                                    .terminate = false,
-                                   .cookie = *cookie,
+                                   .cookie = cookie,
                                }};
         } catch ( const std::exception& e ) {
             unexpectedEventArguments(zeek_instance_id, name, args);


### PR DESCRIPTION
This field is marked `&optional` in the Zeek package and can intentionally be null. The field in `ZeekQuery` is already a `std::optional` so there's no need to dereference it here.