### PR TITLE
Fix CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           brew update
           brew upgrade cmake
-          brew install ninja ccache
+          brew install ninja ccache wget
           pip3 install btest zkg
           # time can be off, which confuses codesigning; this host can be accessed from GH actions
           sudo sntp -sS time.windows.com
@@ -160,7 +160,7 @@ jobs:
         env:
             OPENSSL_VERSION: 1.1.1w
         run: |
-            curl -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+            wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
             tar xvzf openssl-${OPENSSL_VERSION}.tar.gz && mv openssl-${OPENSSL_VERSION} openssl_x86_64
             tar xvzf openssl-${OPENSSL_VERSION}.tar.gz && mv openssl-${OPENSSL_VERSION} openssl_arm64
             (cd openssl_x86_64 && CC="ccache cc" ./Configure darwin64-x86_64-cc no-shared no-tests -mmacosx-version-min=${MACOS_VERSION} && make -j)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,8 @@ repos:
   - id: check-yaml
   - id: check-added-large-files
 
-- repo: https://gitlab.com/daverona/pre-commit/cpp
-  rev: 0.8.0
+- repo: https://github.com/cpplint/cpplint
+  rev: 1.6.1
   hooks:
   - id: cpplint
     args: ["--quiet"]


### PR DESCRIPTION
- Pinned cpplint to the previous version to fix CI issues. The build/include-what-you-use rule in cpplint 2.0.0 no longer supports transitive headers from the header of the current module for parity with the style guide. ([CHANGELOG.rst](https://github.com/cpplint/cpplint/blob/f4363d7fc0d5f38c4fd41b658e069e96583da0d5/CHANGELOG.rst?plain=1#L17))
- Replace curl with wget to download the source code of openssl. (It seems that the download link on the OpenSSL official website does not support `curl`)